### PR TITLE
Take advantage of PostgreSQL 9.5 ON CONFLICT UPDATE.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,6 +151,11 @@ two databases will have independent counters in each database.
 Changelog
 =========
 
+2.2
+---
+
+* Optimized performance on PostgreSQL ≥ 9.5.
+
 2.1
 ---
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,37 @@
+# Usage:
+# PYTHONPATH=. DJANGO_SETTINGS_MODULE=sequences.test_postgresql_settings django-admin migrate
+# PYTHONPATH=. DJANGO_SETTINGS_MODULE=sequences.test_postgresql_settings python benchmark.py
+
+import threading
+import time
+
+import django
+from django.db import connection
+
+from sequences import get_next_value
+
+django.setup()
+
+LOOPS = 500
+THREADS = 20
+
+def get_values():
+    for _ in range(LOOPS):
+        # Add `reset_value=1000` to use SELECT + UPDATE instead of INSERT ON CONFLICT.
+        get_next_value()
+    connection.close()
+
+threads = [threading.Thread(target=get_values) for _ in range(THREADS)]
+
+t0 = time.perf_counter()
+
+for thread in threads:
+    thread.start()
+
+for thread in threads:
+    thread.join()
+
+t1 = time.perf_counter()
+
+print("{} loops x {} threads in {:.2f} seconds = {:.0f} values / second"
+      .format(LOOPS, THREADS, t1 - t0, LOOPS * THREADS / (t1 - t0)))

--- a/sequences/test_postgresql_settings.py
+++ b/sequences/test_postgresql_settings.py
@@ -2,7 +2,6 @@ import os
 
 from .test_settings import *
 
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',

--- a/sequences/tests.py
+++ b/sequences/tests.py
@@ -35,6 +35,7 @@ class SingleConnectionTestsMixin(object):
         with self.assertRaises(AssertionError):
             get_next_value('error', initial_value=1, reset_value=1)
 
+
 class SingleConnectionInAutocommitTests(SingleConnectionTestsMixin,
                                         TransactionTestCase):
     pass


### PR DESCRIPTION
Currently tests don't pass and the nowait parameter is ignored.