### PR TITLE
Add support for max_value to reset the sequence once the max is reached.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,15 @@ transaction gets committed; as discussed above, if the transaction is rolled
 back, the generated value isn't consumed. It's also possible to initialize a
 sequence in a data migration and not use ``initial_value`` in actual code.
 
+Sequences can loop::
+
+    >>> get_next_value('seconds', initial_value=0, reset_value=60)
+
+When the sequence reaches ``reset_value``, it restarts at ``initial_value``.
+In other works, it generates ``reset_value - 2``, ``reset_value - 1``,
+``initial_value``, ``initial_value + 1``, etc. In that case, each call to
+``get_next_value`` must provide ``initial_value`` and ``reset_value``.
+
 Database transactions that call ``get_next_value`` for a given sequence are
 serialized. In other words, when you call ``get_next_value`` in a database
 transaction, other callers which attempt to get a value from the same sequence
@@ -100,7 +109,7 @@ current value is stored in the default database for writing to models of the
 
 To sum up, the complete signature of ``get_next_value`` is::
 
-    get_next_value(sequence_name='default', initial_value=1,
+    get_next_value(sequence_name='default', initial_value=1, reset_value=None,
                    *, nowait=False, using=None)
 
 Under the hood, it relies on the database's transactional integrity to
@@ -141,6 +150,11 @@ two databases will have independent counters in each database.
 
 Changelog
 =========
+
+2.1
+---
+
+* Provide looping sequences with ``reset_value``.
 
 2.0
 ---

--- a/sequences/__init__.py
+++ b/sequences/__init__.py
@@ -3,13 +3,15 @@ from django.db import router, transaction
 
 def get_next_value(
         sequence_name='default', initial_value=1,
-        *, nowait=False, using=None):
+        *, nowait=False, using=None, max_value=None):
     """
     Return the next value for a given sequence.
 
     """
     # Inner import because models cannot be imported before their application.
     from .models import Sequence
+    if max_value:
+        assert initial_value < max_value
 
     if using is None:
         using = router.db_for_write(Sequence)
@@ -38,5 +40,7 @@ def get_next_value(
         )
         if not created:
             sequence.last += 1
+            if max_value and sequence.last > max_value:
+                sequence.last = initial_value
             sequence.save()
         return sequence.last

--- a/sequences/tests.py
+++ b/sequences/tests.py
@@ -304,37 +304,3 @@ class ConcurrencyTests(TransactionTestCase):
         ]
 
         self.assertSequence(one, two, expected)
-
-    def test_max_value_commit(self):
-
-        def one(output):
-            with transaction.atomic():
-                output.append(('one', 'begin'))
-                value = get_next_value(max_value=2)
-                output.append(('one', value))
-                value2 = get_next_value(max_value=2)
-                output.append(('one', value2))
-                time.sleep(0.2)
-                output.append(('one', 'commit'))
-            connection.close()
-
-        def two(output):
-            time.sleep(0.1)
-            with transaction.atomic():
-                output.append(('two', 'begin'))
-                value = get_next_value(max_value=2)
-                output.append(('two', value))
-                output.append(('two', 'commit'))
-            connection.close()
-
-        expected = [
-            ('one', 'begin'),
-            ('one', 1),
-            ('one', 2),
-            ('two', 'begin'),
-            ('one', 'commit'),
-            ('two', 1),
-            ('two', 'commit'),
-        ]
-
-        self.assertSequence(one, two, expected)

--- a/sequences/tests.py
+++ b/sequences/tests.py
@@ -25,14 +25,15 @@ class SingleConnectionTestsMixin(object):
         self.assertEqual(get_next_value('customers', initial_value=1000), 1001)
         self.assertEqual(get_next_value('customers'), 1002)
 
-    def test_max_value(self):
-        self.assertEqual(get_next_value('reference', 1, max_value=2), 1)
-        self.assertEqual(get_next_value('reference', 1, max_value=2), 2)
-        self.assertEqual(get_next_value('reference', 1, max_value=2), 1)
+    def test_reset_value(self):
+        self.assertEqual(get_next_value('reference', 0, reset_value=2), 0)
+        self.assertEqual(get_next_value('reference', 0, reset_value=2), 1)
+        self.assertEqual(get_next_value('reference', 0, 2), 0)
+        self.assertEqual(get_next_value('reference', 0, 2), 1)
 
-    def test_max_value_smaller_then_initial(self):
+    def test_reset_value_smaller_than_initial_value(self):
         with self.assertRaises(AssertionError):
-            get_next_value('error', 1, max_value=1)
+            get_next_value('error', initial_value=1, reset_value=1)
 
 class SingleConnectionInAutocommitTests(SingleConnectionTestsMixin,
                                         TransactionTestCase):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with codecs.open(os.path.join(root_dir, 'README.rst'), encoding='utf-8') as f:
 
 setuptools.setup(
     name='django-sequences',
-    version='2.0',
+    version='2.1',
     description=description,
     long_description=long_description,
     url='https://github.com/aaugustin/django-sequences',


### PR DESCRIPTION
We need to generator incremental number based on a identifier, this seemed the best solution, but because the numbers are used as a reference they should reset at a certain point.

Thus I added a max_value keyword only argument to allow for this.

Also added tests.

Please merge and release a new version so we can use it.