### PR TITLE
Fix encoding and issues with python 2

### DIFF
--- a/sequences/__init__.py
+++ b/sequences/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.db import connections, router, transaction
 
 
@@ -11,8 +12,7 @@ UPSERT_QUERY = """
 
 
 def get_next_value(
-        sequence_name='default', initial_value=1, reset_value=None,
-        *, nowait=False, using=None):
+        sequence_name='default', initial_value=1, reset_value=None, nowait=False, using=None, *args, **kwargs):
     """
     Return the next value for a given sequence.
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+# from __future__ import unicode_literals
 
 import codecs
 import os.path


### PR DESCRIPTION
The file __init__.py contains a unicode character, hence we need to define the file encoding as utf-8. 
Also python 2 doesn't support stararg (*)... 