### PR TITLE
Test on Django 4.0 and Python 3.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,9 @@ return value to the database within the same transaction!**
 Getting started
 ===============
 
-django-sequences is tested with Django 2.2 (LTS), 3.0, 3.1, and 3.2 (LTS).
+django-sequences is tested with Django 2.2 (LTS), 3.0, 3.1, 3.2 (LTS), and 4.0.
+It is also tested with all database backends built-in to Django: MySQL/MariaDB,
+Oracle, PostgreSQL and SQLite.
 
 It is released under the BSD license, like Django itself.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ classifiers = [
     "Framework :: Django :: 2.2",
     "Framework :: Django :: 3.0",
     "Framework :: Django :: 3.1",
+    "Framework :: Django :: 3.2",
+    "Framework :: Django :: 4.0",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
 ]

--- a/tests/mysql_settings.py
+++ b/tests/mysql_settings.py
@@ -5,6 +5,7 @@ from .settings import *  # noqa
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
+        'HOST': os.environ.get('SEQUENCES_MYSQL_HOST', ''),
         'NAME': os.environ.get('SEQUENCES_MYSQL_NAME', 'sequences'),
         'USER': os.environ.get('SEQUENCES_MYSQL_USER', 'sequences'),
         'PASSWORD': os.environ.get('SEQUENCES_MYSQL_PASSWORD', 'sequences'),

--- a/tests/postgresql_settings.py
+++ b/tests/postgresql_settings.py
@@ -5,6 +5,7 @@ from .settings import *  # noqa
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
+        'HOST': os.environ.get('SEQUENCES_POSTGRESQL_HOST', ''),
         'NAME': os.environ.get('SEQUENCES_POSTGRESQL_NAME', 'sequences'),
         'USER': os.environ.get('SEQUENCES_POSTGRESQL_USER', 'sequences'),
         'PASSWORD': os.environ.get(

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,3 +1,5 @@
 INSTALLED_APPS = ['sequences.apps.SequencesConfig']
 
 SECRET_KEY = 'whatever'
+
+USE_TZ = True

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py37-django30
     py38-django31
     py39-django32
+    py310-django40
 
 [testenv]
 deps =
@@ -12,11 +13,13 @@ deps =
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
     django32: Django>=3.1,<3.2
+    django40: Django>=4.0,<4.1
     cx-Oracle
     mysqlclient
     psycopg2-binary
 commands =
-    python -m django test --settings=tests.sqlite_settings
-    python -m django test --settings=tests.postgresql_settings
-    python -m django test --settings=tests.mysql_settings
-    python -m django test --settings=tests.oracle_settings
+    python -W error::ResourceWarning -W error::DeprecationWarning -W error::PendingDeprecationWarning -m django test --settings=tests.sqlite_settings
+    python -W error::ResourceWarning -W error::DeprecationWarning -W error::PendingDeprecationWarning -m django test --settings=tests.postgresql_settings
+    python -W error::ResourceWarning -W error::DeprecationWarning -W error::PendingDeprecationWarning -m django test --settings=tests.mysql_settings
+    python -W error::ResourceWarning -W error::DeprecationWarning -W error::PendingDeprecationWarning -m django test --settings=tests.oracle_settings
+passenv = SEQUENCES_*


### PR DESCRIPTION
Add Django 4.0 on Python 3.10 to the test matrix.

Set `USE_TZ = True` in test settings since without it Django 4.0 raises a deprecation warning.

Add the ability to pass environment variables through `tox` with [`passenv`](https://tox.wiki/en/latest/config.html#conf-passenv).

Add Python flags to fail for resource and depreaction warnings - this is something I like to do for libraries to check that warnings aren't passed on to users.

Update the docs and PyPI classifiers.